### PR TITLE
fix array concatenation bug

### DIFF
--- a/pygeogrids/grids.py
+++ b/pygeogrids/grids.py
@@ -788,9 +788,9 @@ class CellGrid(BasicGrid):
             lons.append(self.activearrlon[cell_index])
             lats.append(self.activearrlat[cell_index])
 
-        gpis = np.array(gpis)
-        lons = np.array(lons)
-        lats = np.array(lats)
+        gpis = np.hstack(gpis)
+        lons = np.hstack(lons)
+        lats = np.hstack(lats)
 
         return gpis, lons, lats
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -174,11 +174,13 @@ class TestCellGrid(unittest.TestCase):
 
         for cell in cells:
             gpis, lons, lats = subgrid.grid_points_for_cell(cell)
-            orig_gpis, orig_lons, orig_lats = \
-                self.cellgrid.grid_points_for_cell(cell)
-            nptest.assert_equal(gpis, orig_gpis)
-            nptest.assert_equal(lons, orig_lons)
-            nptest.assert_equal(lats, orig_lats)
+            cell_index = np.where(cell == self.cellgrid.activearrcell)
+            orig_gpis = self.cellgrid.activegpis[cell_index]
+            orig_lons = self.cellgrid.activearrlon[cell_index]
+            orig_lats = self.cellgrid.activearrlat[cell_index]
+            nptest.assert_array_equal(gpis, orig_gpis)
+            nptest.assert_array_equal(lons, orig_lons)
+            nptest.assert_array_equal(lats, orig_lats)
 
     def test_subgrid_from_gpis(self):
         """


### PR DESCRIPTION
This bug cause an extra dimension since due to the concatenation of list of arrays into a new array. Using `np.hstack` the problem is resolved.