### PR TITLE
Improvements to netcdf storage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,12 @@
 Changelog
 =========
 
-v0.1.10
+v0.1.xx
 =======
 
 - fix bug in storing/loading grids with shape attribute set.
+- change equality check of grids to be more flexible. Now only a match of the
+  tuples gpi, lon, lat, cell is checked. The order does no longer matter.
 
 v0.1.9
 ======

--- a/pygeogrids/grids.py
+++ b/pygeogrids/grids.py
@@ -624,19 +624,26 @@ class BasicGrid(object):
             Returns True if grids are equal.
         """
         # only test to certain significance for float variables
+        # grids are assumed to be the same if the gpi, lon, lat tuples are the
+        # same
+        idx_gpi = np.argsort(self.gpis)
+        idx_gpi_other = np.argsort(other.gpis)
+        gpisame = np.all(self.gpis[idx_gpi] == other.gpis[idx_gpi_other])
         try:
-            nptest.assert_allclose(self.arrlon, other.arrlon)
+            nptest.assert_allclose(self.arrlon[idx_gpi],
+                                   other.arrlon[idx_gpi_other])
             lonsame = True
         except AssertionError:
             lonsame = False
         try:
-            nptest.assert_allclose(self.arrlat, other.arrlat)
+            nptest.assert_allclose(self.arrlat[idx_gpi],
+                                   other.arrlat[idx_gpi_other])
             latsame = True
         except AssertionError:
             latsame = False
-        gpisame = np.all(self.gpis == other.gpis)
         if self.subset is not None and other.subset is not None:
-            subsetsame = np.all(self.subset == other.subset)
+            subsetsame = np.all(
+                sorted(self.gpis[self.subset]) == sorted(other.gpis[other.subset]))
         elif self.subset is None and other.subset is None:
             subsetsame = True
         else:
@@ -944,7 +951,10 @@ class CellGrid(BasicGrid):
             Returns true if equal.
         """
         basicsame = super(CellGrid, self).__eq__(other)
-        cellsame = np.all(self.arrcell == other.arrcell)
+        idx_gpi = np.argsort(self.gpis)
+        idx_gpi_other = np.argsort(other.gpis)
+        cellsame = np.all(self.arrcell[idx_gpi]
+                          == other.arrcell[idx_gpi_other])
         return np.all([basicsame, cellsame])
 
 

--- a/pygeogrids/netcdf.py
+++ b/pygeogrids/netcdf.py
@@ -220,7 +220,7 @@ def save_lonlat(filename, arrlon, arrlat, geodatum, arrcell=None,
 
 
 def save_grid(filename, grid, subset_name='subset_flag',
-              subset_meaning="water, land", global_attrs=None):
+              subset_meaning='water land', global_attrs=None):
     """
     save a BasicGrid or CellGrid to netCDF
     it is assumed that a subset should be used as land_points

--- a/pygeogrids/netcdf.py
+++ b/pygeogrids/netcdf.py
@@ -219,6 +219,56 @@ def save_lonlat(filename, arrlon, arrlat, geodatum, arrcell=None,
             ncfile.setncatts(global_attrs)
 
 
+def sort_for_netcdf(lons, lats, values):
+    """
+    Sort an 2D array for storage in a netCDF file.
+    This mans that the latitudes are stored from
+    90 to -90 and the longitudes from -180 to 180.
+    Input arrays have to have shape latdim, londim
+    which would mean for a global 10 degree grid (18, 36).
+
+    Parameters
+    ----------
+    lons: numpy.ndarray
+        2D numpy array of longitudes
+    lats: numpy.ndarray
+        2D numpy array of latitudes
+    values: numpy.ndarray
+        2D numpy array of values to sort
+
+    Returns
+    -------
+    lons: numpy.ndarray
+        2D numpy array of longitudes, sorted
+    lats: numpy.ndarray
+        2D numpy array of latitudes, sorted
+    values: numpy.ndarray
+        2D numpy array of values to sort, sorted
+    """
+
+    arrlat = lats.flatten()
+    arrlon = lons.flatten()
+    arrval = values.flatten()
+    idxlatsrt = np.argsort(arrlat)[::-1]
+    idxlat = np.argsort(arrlat[idxlatsrt].
+                        reshape(lats.shape),
+                        axis=0)[::-1]
+    idxlon = np.argsort(arrlon[idxlatsrt].
+                        reshape(lons.shape)
+                        [idxlat, np.arange(lons.shape[1])], axis=1)
+
+    values = arrval[idxlatsrt].reshape(*lons.shape)\
+        [idxlat, np.arange(lons.shape[1])]\
+        [np.arange(lons.shape[0])[:, None], idxlon]
+    lons = arrlon[idxlatsrt].reshape(*lons.shape)\
+        [idxlat, np.arange(lons.shape[1])]\
+        [np.arange(lons.shape[0])[:, None], idxlon]
+    lats = arrlat[idxlatsrt].reshape(*lons.shape)\
+        [idxlat, np.arange(lons.shape[1])]\
+        [np.arange(lons.shape[0])[:, None], idxlon]
+    return lons, lats, values
+
+
 def save_grid(filename, grid, subset_name='subset_flag',
               subset_meaning='water land', global_attrs=None):
     """

--- a/tests/test_netcdf.py
+++ b/tests/test_netcdf.py
@@ -187,6 +187,43 @@ class Test(unittest.TestCase):
         loaded_grid = grid_nc.load_grid(self.testfile)
         assert self.cellgrid_shape == loaded_grid
 
+def test_sort_lon_lat_for_netcdf_transposed():
+    """
+    Test the sorting of an array for netcdf storage
+    """
+    londim = np.arange(-180.0, 180.0, 60)
+    latdim = np.arange(90.0, -90.0, -30)
+    lats, lons = np.meshgrid(latdim, londim)
+    gpis = np.arange(lons.flatten().size).reshape(lons.shape)
+    rand_idx = np.random.permutation(gpis.flatten().size)
+    lons_rand = lons.flatten()[rand_idx].reshape(lons.shape)
+    lats_rand = lats.flatten()[rand_idx].reshape(lats.shape)
+    gpis_rand = gpis.flatten()[rand_idx].reshape(gpis.shape)
+    lons_sorted, lats_sorted, gpis_sorted = grid_nc.sort_for_netcdf(
+        lons_rand, lats_rand, gpis_rand)
+    nptest.assert_almost_equal(lons_sorted, lons.T)
+    nptest.assert_almost_equal(lats_sorted, lats.T)
+    nptest.assert_almost_equal(gpis_sorted, gpis.T)
+
+
+def test_sort_lon_lat_for_netcdf():
+    """
+    Test the sorting of an array for netcdf storage
+    """
+    londim = np.arange(-180.0, 180.0, 60)
+    latdim = np.arange(90.0, -90.0, -30)
+    lons, lats = np.meshgrid(londim, latdim)
+    gpis = np.arange(lons.flatten().size).reshape(lons.shape)
+    rand_idx = np.random.permutation(gpis.flatten().size)
+    lons_rand = lons.flatten()[rand_idx].reshape(lons.shape)
+    lats_rand = lats.flatten()[rand_idx].reshape(lats.shape)
+    gpis_rand = gpis.flatten()[rand_idx].reshape(gpis.shape)
+    lons_sorted, lats_sorted, gpis_sorted = grid_nc.sort_for_netcdf(
+        lons_rand, lats_rand, gpis_rand)
+    nptest.assert_almost_equal(lons_sorted, lons)
+    nptest.assert_almost_equal(lats_sorted, lats)
+    nptest.assert_almost_equal(gpis_sorted, gpis)
+
 if __name__ == "__main__":
     # import sys;sys.argv = ['', 'Test.testName']
     unittest.main()

--- a/tests/test_netcdf.py
+++ b/tests/test_netcdf.py
@@ -89,23 +89,6 @@ class Test(unittest.TestCase):
                 self.subset, np.where(nc_data.variables['subset_flag'][:] == 1)[0])
             assert nc_data.test == 'test_attribute'
 
-    def test_save_basicgrid_nc(self):
-        grid_nc.save_grid(self.testfile,
-                          self.basic,
-                          global_attrs={'test': 'test_attribute'})
-
-        with Dataset(self.testfile) as nc_data:
-            nptest.assert_array_equal(np.unique(self.lats)[::-1],
-                                      nc_data.variables['lat'][:])
-            nptest.assert_array_equal(np.unique(self.lons),
-                                      nc_data.variables['lon'][:])
-
-            nptest.assert_array_equal(self.subset,
-                                      np.where(nc_data.variables['subset_flag'][:].flatten() == 1)[0])
-            assert nc_data.test == 'test_attribute'
-            assert nc_data.shape[1] == 180
-            assert nc_data.shape[0] == 360
-
     def test_save_basicgrid_generated(self):
         grid_nc.save_grid(self.testfile,
                           self.basic,


### PR DESCRIPTION
- Additional options for netcdf format and compression.
- arrlon/arrlat/gpi are now sorted properly before converting to 2D shape
- comma (colon) in default subset meaning string removed (CF conventions)

supersedes https://github.com/TUW-GEO/pygeogrids/pull/36