### PR TITLE
Shape definition changed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ notifications:
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ install:
   # conditionally because it saves us some downloading if the version is
   # the same.
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget http://repo.continuum.io/miniconda/Miniconda-3.4.2-Linux-x86_64.sh -O miniconda.sh;
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
     else
-      wget http://repo.continuum.io/miniconda/Miniconda3-3.4.2-Linux-x86_64.sh -O miniconda.sh;
+      wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy netCDF4 pytest pip
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy netCDF4 pytest pip pyproj
   - source activate test-environment
   - pip install pykdtree
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,8 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy netCDF4 pytest pip pyproj
-  - source activate test-environment
-  - pip install pykdtree
+  - conda env create -f environment.yml
+  - source activate pygeogrids
   - python setup.py install
 
 script:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,12 +2,17 @@
 Changelog
 =========
 
-v0.1.xx
+v0.2.xx
 =======
 
 - fix bug in storing/loading grids with shape attribute set.
 - change equality check of grids to be more flexible. Now only a match of the
   tuples gpi, lon, lat, cell is checked. The order does no longer matter.
+- Shape definition changed to correspond to what one would expect. Now a 1x1
+  regular global grid has the shape (180, 360) corresponding to the 180 rows and
+  360 columns that the array has. This was necessary since the genreg_grid
+  function produced grids with wrong lon2d, lat2d arrays because the shape was
+  not correct
 
 v0.1.9
 ======

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,24 @@
+name: pygeogrids
+dependencies:
+- curl=7.45.0=0
+- hdf5=1.8.15.1=2
+- libnetcdf=4.3.3.1=3
+- mkl=11.3.3=0
+- netcdf4=1.2.2=np111py27_0
+- numpy=1.11.0=py27_1
+- openssl=1.0.2h=1
+- pip=8.1.1=py27_1
+- proj.4=4.9.1=0
+- py=1.4.31=py27_0
+- pyproj=1.9.4=py27_1
+- pytest=2.9.1=py27_0
+- python=2.7.11=0
+- readline=6.2=2
+- setuptools=21.2.1=py27_0
+- sqlite=3.13.0=0
+- tk=8.5.18=0
+- wheel=0.29.0=py27_0
+- zlib=1.2.8=3
+- pip:
+  - pykdtree==1.1.1
+

--- a/pygeogrids/grids.py
+++ b/pygeogrids/grids.py
@@ -83,13 +83,13 @@ class BasicGrid(object):
         search will be built on initialization
     shape : tuple, optional
         The shape of the grid array in 2-d space.
-        e.g. for a 1x1 degree global regular grid the shape would be (360,180).
+        e.g. for a 1x1 degree global regular grid the shape would be (180,360).
         if given the grid can be reshaped into the given shape
         this indicates that it is a regular grid and fills the
         attributes self.lon2d and self.lat2d which
         define the grid only be the meridian coordinates(self.lon2d) and
         the coordinates of the circles of latitude(self.lat2d).
-        The shape has to be given as (lon2d, lat2d)
+        The shape has to be given as (lat2d, lon2d)
         It it is not given the shape is set to the length of the input
         lon and lat arrays.
 
@@ -461,8 +461,8 @@ class BasicGrid(object):
                 pos = np.searchsorted(self.gpis[gpisorted], gpi)
                 index = gpisorted[pos]
 
-            index_lat = (index / self.shape[0]).astype(np.int)
-            index_lon = index % self.shape[0]
+            index_lat = (index / self.shape[1]).astype(np.int)
+            index_lon = index % self.shape[1]
             if not iterable:
                 index_lat = index_lat[0]
                 index_lon = index_lon[0]
@@ -1016,7 +1016,7 @@ def gridfromdims(londim, latdim, **kwargs):
     """
     lons, lats = np.meshgrid(londim, latdim)
     return BasicGrid(lons.flatten(), lats.flatten(),
-                     shape=(len(londim), len(latdim)), **kwargs)
+                     shape=(len(latdim), len(londim)), **kwargs)
 
 
 def genreg_grid(grd_spc_lat=1, grd_spc_lon=1, minlat=-90.0, maxlat=90.0,

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -130,8 +130,8 @@ class TestCellGridNotGpiDirect(unittest.TestCase):
         self.lon, self.lat = np.meshgrid(self.londim, self.latdim)
         self.grid = grids.BasicGrid(self.lon.flatten(), self.lat.flatten(),
                                     gpis=np.arange(self.lon.flatten().size),
-                                    shape=(len(self.londim),
-                                           len(self.latdim)))
+                                    shape=(len(self.latdim),
+                                           len(self.londim)))
         self.cellgrid = self.grid.to_cell_grid()
 
     def test_gpi2cell(self):
@@ -164,8 +164,8 @@ class TestCellGridNotGpiDirect(unittest.TestCase):
         """
         self.custom_gpi_grid = \
             grids.BasicGrid(self.lon.flatten(), self.lat.flatten(),
-                            shape=(len(self.londim),
-                                   len(self.latdim)),
+                            shape=(len(self.latdim),
+                                   len(self.londim)),
                             gpis=np.arange(len(self.lat.flatten()))[::-1])
         self.custom_gpi_cell_grid = self.custom_gpi_grid.to_cell_grid()
         gpi = [200, 255]
@@ -219,8 +219,8 @@ class TestCellGrid(unittest.TestCase):
         self.londim = np.arange(-180, 180, 2.5)
         self.lon, self.lat = np.meshgrid(self.londim, self.latdim)
         self.grid = grids.BasicGrid(self.lon.flatten(), self.lat.flatten(),
-                                    shape=(len(self.londim),
-                                           len(self.latdim)))
+                                    shape=(len(self.latdim),
+                                           len(self.londim)))
         self.cellgrid = self.grid.to_cell_grid()
 
     def test_gpi2cell(self):
@@ -325,8 +325,8 @@ class Test_2Dgrid(unittest.TestCase):
         self.londim = np.arange(-180, 180, 2.5)
         self.lon, self.lat = np.meshgrid(self.londim, self.latdim)
         self.grid = grids.BasicGrid(self.lon.flatten(), self.lat.flatten(),
-                                    shape=(len(self.londim),
-                                           len(self.latdim)))
+                                    shape=(len(self.latdim),
+                                           len(self.londim)))
 
     def test_gpi2rowcol(self):
         """
@@ -367,8 +367,8 @@ class Test_2Dgrid(unittest.TestCase):
         """
         self.custom_gpi_grid = grids.BasicGrid(self.lon.flatten(),
                                                self.lat.flatten(),
-                                               shape=(len(self.londim),
-                                                      len(self.latdim)),
+                                               shape=(len(self.latdim),
+                                                      len(self.londim)),
                                                gpis=np.arange(len(self.lat.flatten()))[::-1])
         gpi = [200, 255]
         row_should = [70, 70]
@@ -388,6 +388,13 @@ class Test_2Dgrid(unittest.TestCase):
         assert lon == lon_should
         assert lat == lat_should
 
+    def test_lonlat2d(self):
+        """
+        Test if lonlat 2d grids are the same as the grids used for making the grid.
+        """
+        assert np.all(self.lon == self.grid.lon2d)
+        assert np.all(self.lat == self.grid.lat2d)
+
     def test_tocellgrid(self):
         """
         test if to_cell_grid method works correctly
@@ -402,10 +409,13 @@ def test_genreggrid():
     Test generation of regular grids.
     """
     grid = grids.genreg_grid()
-    assert grid.shape == (360, 180)
+    assert grid.shape == (180, 360)
     lon, lat = grid.gpi2lonlat(3)
     assert lon == -176.5
     assert lat == 89.5
+    lon, lat = grid.gpi2lonlat(360)
+    assert lon == -179.5
+    assert lat == 88.5
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Shape definition changed to correspond to what one would expect. Now a
1x1 regular global grid has the shape (180, 360) corresponding to the
180 rows and 360 columns that the array has. This was necessary since
the genreg_grid function produced grids with wrong lon2d, lat2d arrays
because the shape was not correct.

@sebhahn @d-chung @christophreimer This could under certain circumstances break some code. The main one I can think of would be when loading an grid from a netCDF file then gpi2rowcol will produce wrong results.