### PR TITLE
Remove clipping from lonlat2cell

### DIFF
--- a/src/pygeogrids/grids.py
+++ b/src/pygeogrids/grids.py
@@ -1224,12 +1224,8 @@ def lonlat2cell(lon, lat, cellsize=5.0, cellsize_lon=None, cellsize_lat=None):
         cellsize_lon = cellsize
     if cellsize_lat is None:
         cellsize_lat = cellsize
-    y = np.clip(
-        np.floor((np.double(lat) + (np.double(90.0) + 1e-9)) / cellsize_lat), 0, 180
-    )
-    x = np.clip(
-        np.floor((np.double(lon) + (np.double(180.0) + 1e-9)) / cellsize_lon), 0, 360
-    )
+    y = np.floor((np.double(lat) + (np.double(90.0) + 1e-9)) / cellsize_lat)
+    x = np.floor((np.double(lon) + (np.double(180.0) + 1e-9)) / cellsize_lon)
     cells = np.int32(x * (np.double(180.0) / cellsize_lat) + y)
 
     max_cells = (np.double(180.0) / cellsize_lat) * (np.double(360.0)) / cellsize_lon


### PR DESCRIPTION
When using the current implementation of `lonlat2cell` with cellsize < 1, the clipping messes up cells, because everything in the upper right corner of the map is mapped to the same cell.

For example, with `cellsize=0.5` all points with lat>0 and lon>0, we will get `y = (lat+90)/cellsize = (lat+90)*2 > 180` and similarly `x = (lon+180)/cellsize = (lon+180)*2 > 360`, and due to clipping they all will be assigned `y = 180` and `x = 360`.

When using cellsize >= 1, clipping is only necessary if latitude and longitude are not in (-90, 90) and (-180, 180), respectively, but this is already enforced in the BasicGrid init, so it shouldn't be necessary here.

Therefore I think it's safe to remove the clipping here.