### PR TITLE
BaseGrid __eq__ method no longer uses elementwise comparison

### DIFF
--- a/src/pygeogrids/grids.py
+++ b/src/pygeogrids/grids.py
@@ -786,7 +786,7 @@ class BasicGrid(object):
         # same
         idx_gpi = np.argsort(self.gpis)
         idx_gpi_other = np.argsort(other.gpis)
-        gpisame = np.all(self.gpis[idx_gpi] == other.gpis[idx_gpi_other])
+        gpisame = np.array_equal(self.gpis[idx_gpi], other.gpis[idx_gpi_other])
         try:
             nptest.assert_allclose(self.arrlon[idx_gpi], other.arrlon[idx_gpi_other])
             lonsame = True


### PR DESCRIPTION
If grids are not equal, numpy throws a Deprecation warning for elementwise comparison:
```
/home/charriso/micromamba/envs/ascat_env/lib/python3.8/site-packages/numpy/ma/core.py:4123: DeprecationWarning: elementwise comparison failed; this will raise an error in the future.
  check = compare(sdata, odata)
```
Using np.array_equal(arr1, arr2) rather than np.all(arr1==arr2) should fix this