### PR TITLE
CellGrid __eq__ method no longer uses elementwise comparison

### DIFF
--- a/src/pygeogrids/grids.py
+++ b/src/pygeogrids/grids.py
@@ -1131,7 +1131,7 @@ class CellGrid(BasicGrid):
         basicsame = super(CellGrid, self).__eq__(other)
         idx_gpi = np.argsort(self.gpis)
         idx_gpi_other = np.argsort(other.gpis)
-        cellsame = np.all(self.arrcell[idx_gpi] == other.arrcell[idx_gpi_other])
+        cellsame = np.array_equal(self.arrcell[idx_gpi], other.arrcell[idx_gpi_other])
         return np.all([basicsame, cellsame])
 
     def get_bbox_grid_points(


### PR DESCRIPTION
If grids are not equal, numpy throws a Deprecation warning for elementwise comparison:
```
/home/charriso/micromamba/envs/ascat_env/lib/python3.8/site-packages/numpy/ma/core.py:4123: DeprecationWarning: elementwise comparison failed; this will raise an error in the future.
  check = compare(sdata, odata)
```
Using np.array_equal(arr1, arr2) rather than np.all(arr1==arr2) should fix this